### PR TITLE
文件上传支持blob类型

### DIFF
--- a/src/Request.js
+++ b/src/Request.js
@@ -153,7 +153,7 @@ Request.prototype = {
       // 兼容传[json string] [formData] 的情况,暂时这两种. 其他的看情况
       if (toString.call(data) === '[object Object]') {
         // 如果存在File，就用表单上传
-        if (_.find(data, v => toString.call(v) === '[object File]')) {
+        if (_.find(data, v => /\[object File\]|\[object Blob\]/.test(toString.call(v)))) {
           body = new window.FormData()
           for (var e in data) {
             body.append(e, data[e])


### PR DESCRIPTION
使用`canvas`压缩图片，然后转成`file`类型上传遇到一个问题，测试员的手机`iphone x`会出现后端接收到的图片大小为`0`的情况，如果压缩后转成`blob`类型就不会，原因不明